### PR TITLE
Add support for query endpoint

### DIFF
--- a/maap.cfg
+++ b/maap.cfg
@@ -13,7 +13,7 @@ algorithm_build = http://%(maap_host)s/api/algorithm/build
 job_status = http://%(maap_host)s/api/job/status
 wmts = http://%(maap_host)s/api/wmts
 tiler_endpoint = https://8e9mu91qr6.execute-api.us-east-1.amazonaws.com/production
-query_endpoint = http://%(maap_host)s/api/query
+query_endpoint = https://%(maap_host)s/api/query/
 
 [aws]
 aws_access_key_id = ${AWS_ACCESS_KEY_ID}

--- a/maap.cfg
+++ b/maap.cfg
@@ -13,6 +13,7 @@ algorithm_build = http://%(maap_host)s/api/algorithm/build
 job_status = http://%(maap_host)s/api/job/status
 wmts = http://%(maap_host)s/api/wmts
 tiler_endpoint = https://8e9mu91qr6.execute-api.us-east-1.amazonaws.com/production
+query_endpoint = http://%(maap_host)s/api/query
 
 [aws]
 aws_access_key_id = ${AWS_ACCESS_KEY_ID}

--- a/maap/errors.py
+++ b/maap/errors.py
@@ -1,0 +1,2 @@
+class QueryTimeout(Exception):
+  pass

--- a/maap/errors.py
+++ b/maap/errors.py
@@ -1,2 +1,5 @@
 class QueryTimeout(Exception):
   pass
+
+class QueryFailure(Exception):
+  pass

--- a/maap/maap.py
+++ b/maap/maap.py
@@ -243,7 +243,7 @@ class MAAP(object):
             # Instead, we'll make the POST again to the new URL.
             redirect_url = response.headers.get('Location', url)
             if (redirect_url is not url and response.is_redirect and redirect_count < max_redirects):
-                print(f'Received redirect at {url}. Retrying query at {redirect_url}')
+                logger.debug(f'Received redirect at {url}. Retrying query at {redirect_url}')
                 url = redirect_url
                 redirect_count += 1
             else:

--- a/maap/maap.py
+++ b/maap/maap.py
@@ -3,14 +3,19 @@ import os
 import requests
 import json
 import urllib.parse
+import time
 from mapboxgl.utils import *
 from mapboxgl.viz import *
+from datetime import datetime
 
 import xml.etree.ElementTree as ET
 from .Result import Collection, Granule
 from .Dictlist import Dictlist
 from .xmlParser import XmlDictConfig
 from maap.utils.Presenter import Presenter
+from .errors import QueryTimeout
+
+logger = logging.getLogger(__name__)
 
 try:
     from configparser import ConfigParser
@@ -48,6 +53,7 @@ class MAAP(object):
         self._WMTS = self.config.get("service", "wmts")
         self._TILER_ENDPOINT = self.config.get("service", "tiler_endpoint")
         self._MAAP_HOST = self.config.get("service", "maap_host")
+        self._QUERY_ENDPOINT =  self.config.get("service", "query_endpoint")
 
         self._AWS_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY_ID") or self.config.get("aws", "aws_access_key_id")
         self._AWS_ACCESS_SECRET = os.environ.get("AWS_SECRET_ACCESS_KEY") or self.config.get("aws", "aws_secret_access_key")
@@ -101,7 +107,7 @@ class MAAP(object):
         :param kwargs: search parameters
         :return: list of results (<Instance of Result>)
         """
-        logging.info("======== Waiting for response ========")
+        logger.info("======== Waiting for response ========")
 
         page_num = 1
         results = []
@@ -194,6 +200,60 @@ class MAAP(object):
             headers=self._API_HEADER
         )
         return response
+
+    def executeQuery(self, src, query={}, results=True, timeout=180, wait_interval=.5):
+        """
+        Helper to execute query and poll results URL until results are returned
+        or timeout is reached.
+
+        src -- a dict-like object stipulating which dataset is to be queried.
+            Object must contain either a 'Granule' or 'Collection' key.
+            Collection-related value must contain 'ShortName' and 'VersionId'
+            entries. Granule-related value must contain a 'Collection' entry,
+            complying with aforementioned 'Collection' object requirements.
+        query -- dict-like object describing parameters for query (default {}).
+            Currently support paramaters:
+                - bbox -- optional GeoJSON-compliant bounding box (minX, minY,
+                    maxX, maxY) by which to filter data (default [], meaning no
+                    filter)
+                - fields -- optional list of fields to return in query response
+                    (default [], returning all fields)
+        results -- system will poll for results and return results response if
+            True, otherwise will return response from Query Service  (default True)
+        timeout -- max number of seconds to wait for response, only used if
+            results=True (default 180)
+        wait_interval -- number of seconds to wait between each poll for
+            results, only used if results=True (default .5)
+        """
+        response = requests.post(
+            url=self._QUERY_ENDPOINT,
+            headers=dict(Accept='application/json'),
+            json=dict(src=src, query=query)
+        )
+        if not results:
+            # Return the response of query execution
+            return response
+
+        response.raise_for_status()
+        execution = response.json()
+        results = execution['results']
+
+        # Poll results
+        start = datetime.now()
+        while (datetime.now() - start).seconds < timeout:
+            r = requests.get(url=results)
+
+            if r.status_code == 200:
+                # Return the response of query results
+                return r
+
+            if r.status_code == 404:
+                continue
+
+            r.raise_for_status()
+            time.sleep(wait_interval)
+
+        raise QueryTimeout('Query results did not appear within {} seconds'.format(timeout))
 
     def _get_browse(self, granule_ur):
         response = requests.get(

--- a/maap/maap.py
+++ b/maap/maap.py
@@ -211,7 +211,8 @@ class MAAP(object):
             must contain a 'Collection' entry, complying with aforementioned
             'Collection' object requirements.
         query -- dict-like object describing parameters for query (default {}).
-            Currently support paramaters:
+            Currently supported parameters:
+                - where -- a dict-like object used for filtering query
                 - bbox -- optional GeoJSON-compliant bounding box (minX, minY,
                     maxX, maxY) by which to filter data (default [], meaning no
                     filter)

--- a/maap/maap.py
+++ b/maap/maap.py
@@ -13,7 +13,7 @@ from .Result import Collection, Granule
 from .Dictlist import Dictlist
 from .xmlParser import XmlDictConfig
 from maap.utils.Presenter import Presenter
-from .errors import QueryTimeout
+from .errors import QueryTimeout, QueryFailed
 
 logger = logging.getLogger(__name__)
 
@@ -245,6 +245,10 @@ class MAAP(object):
 
             if r.status_code == 200:
                 # Return the response of query results
+                if r.headers.get('x-amz-meta-failed'):
+                    raise QueryFailed(
+                        f'The backing query service failed to process query:\n{r.text}'
+                    )
                 return r
 
             if r.status_code == 404:

--- a/maap/maap.py
+++ b/maap/maap.py
@@ -13,7 +13,7 @@ from .Result import Collection, Granule
 from .Dictlist import Dictlist
 from .xmlParser import XmlDictConfig
 from maap.utils.Presenter import Presenter
-from .errors import QueryTimeout, QueryFailed
+from .errors import QueryTimeout, QueryFailure
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +174,6 @@ class MAAP(object):
 
         return result
 
-
     def searchCollection(self, limit=100, **kwargs):
         """
         Search the CMR collections
@@ -207,10 +206,10 @@ class MAAP(object):
         or timeout is reached.
 
         src -- a dict-like object stipulating which dataset is to be queried.
-            Object must contain either a 'Granule' or 'Collection' key.
-            Collection-related value must contain 'ShortName' and 'VersionId'
-            entries. Granule-related value must contain a 'Collection' entry,
-            complying with aforementioned 'Collection' object requirements.
+            Object must contain 'Collection' key. 'Collection' value must
+            contain 'ShortName' and 'VersionId' entries. Granule-related value
+            must contain a 'Collection' entry, complying with aforementioned
+            'Collection' object requirements.
         query -- dict-like object describing parameters for query (default {}).
             Currently support paramaters:
                 - bbox -- optional GeoJSON-compliant bounding box (minX, minY,
@@ -246,7 +245,7 @@ class MAAP(object):
             if r.status_code == 200:
                 # Return the response of query results
                 if r.headers.get('x-amz-meta-failed'):
-                    raise QueryFailed(
+                    raise QueryFailure(
                         f'The backing query service failed to process query:\n{r.text}'
                     )
                 return r

--- a/test/test_MAAP.py
+++ b/test/test_MAAP.py
@@ -116,3 +116,257 @@ class TestMAAP(TestCase):
         th = TokenHandler("a-K9YbTr8h112zW5pLV8Fw")
         token = th.get_access_token()
         self.assertTrue(token != 'unauthorized' and len(token) > 0)
+
+    def test_executeQuery(self):
+        response = self.maap.executeQuery(
+            src={
+                "Collection": {
+                    "ShortName": "GEDI Cal/Val Field Data_1",
+                    "VersionId": "001"
+                }
+            },
+            query={
+                "bbox": [
+                -122.6,
+                38.4,
+                -122.5,
+                38.5
+                ],
+                "fields": ['project', 'plot', 'p.geom']
+            }
+        )
+        self.assertEqual(
+            response.json(),
+            [
+                {
+                    "project":"usa_sonoma",
+                    "plot":"11",
+                    "p.geom":"POINT(538336.000000 4257761.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"23",
+                    "p.geom":"POINT(538276.000000 4257822.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"49",
+                    "p.geom":"POINT(538274.000000 4257876.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"4",
+                    "p.geom":"POINT(537433.000000 4257430.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"18",
+                    "p.geom":"POINT(537765.000000 4257253.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"48",
+                    "p.geom":"POINT(538727.000000 4257633.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"12a",
+                    "p.geom":"POINT(538128.000000 4257546.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"4",
+                    "p.geom":"POINT(537433.000000 4257430.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"18",
+                    "p.geom":"POINT(537765.000000 4257253.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"12a",
+                    "p.geom":"POINT(538128.000000 4257546.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"11",
+                    "p.geom":"POINT(538336.000000 4257761.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"23",
+                    "p.geom":"POINT(538276.000000 4257822.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"49",
+                    "p.geom":"POINT(538274.000000 4257876.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"11",
+                    "p.geom":"POINT(538336.000000 4257761.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"18",
+                    "p.geom":"POINT(537765.000000 4257253.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"49",
+                    "p.geom":"POINT(538274.000000 4257876.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"8a",
+                    "p.geom":"POINT(537587.000000 4257361.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"11",
+                    "p.geom":"POINT(538336.000000 4257761.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"36",
+                    "p.geom":"POINT(539266.000000 4257157.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"49",
+                    "p.geom":"POINT(538274.000000 4257876.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"4",
+                    "p.geom":"POINT(537433.000000 4257430.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"18",
+                    "p.geom":"POINT(537765.000000 4257253.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"48",
+                    "p.geom":"POINT(538727.000000 4257633.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"8a",
+                    "p.geom":"POINT(537587.000000 4257361.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"4",
+                    "p.geom":"POINT(537433.000000 4257430.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"18",
+                    "p.geom":"POINT(537765.000000 4257253.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"48",
+                    "p.geom":"POINT(538727.000000 4257633.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"12a",
+                    "p.geom":"POINT(538128.000000 4257546.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"4",
+                    "p.geom":"POINT(537433.000000 4257430.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"18",
+                    "p.geom":"POINT(537765.000000 4257253.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"36",
+                    "p.geom":"POINT(539266.000000 4257157.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"48",
+                    "p.geom":"POINT(538727.000000 4257633.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"12a",
+                    "p.geom":"POINT(538128.000000 4257546.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"11",
+                    "p.geom":"POINT(538336.000000 4257761.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"23",
+                    "p.geom":"POINT(538276.000000 4257822.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"45",
+                    "p.geom":"POINT(539261.000000 4257132.000000)"
+                },
+                {
+                    "project":"usa_sonoma",
+                    "plot":"49",
+                    "p.geom": "POINT(538274.000000 4257876.000000)"
+                }
+            ]
+        )


### PR DESCRIPTION
This is a very simple helper to allow a user to send a query to the Query Service. It supports both synchronous requests (i.e. blocking until results are available) and async requests (just getting the URL of the results.

When query is running in a synchronous fashion, if a query fails then a `QueryFailure` error will be thrown.