### PR TITLE
Update bucket for uploadFiles

### DIFF
--- a/maap.cfg
+++ b/maap.cfg
@@ -23,8 +23,8 @@ query_endpoint = query/
 [aws]
 aws_access_key_id = ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
-user_upload_bucket = maap-landing-zone
-user_upload_directory = user-added/uploaded_objects
+user_upload_bucket = maap-landing-zone-gccops
+user_upload_directory = user-added
 
 [search]
 indexed_attributes = [

--- a/maap.cfg
+++ b/maap.cfg
@@ -24,7 +24,7 @@ query_endpoint = query/
 aws_access_key_id = ${AWS_ACCESS_KEY_ID}
 aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}
 user_upload_bucket = maap-landing-zone-gccops
-user_upload_directory = user-added
+user_upload_directory = user-added/uploaded_objects
 
 [search]
 indexed_attributes = [

--- a/maap/maap.py
+++ b/maap/maap.py
@@ -98,7 +98,7 @@ class MAAP(object):
         :param objectKey (string) - S3 directory and filename to upload the local file to
         :return: S3 upload_file response
         """
-        return s3_client.upload_file(filename, bucket, objectKey, ExtraArgs={'ACL': 'bucket-owner-full-control'})
+        return s3_client.upload_file(filename, bucket, objectKey)
 
     def searchGranule(self, limit=20, **kwargs):
         """


### PR DESCRIPTION
We were getting a 403 error resulting first from the fact that the MAAP ADE user had a policy attached MAAPOpsS3FullAccess which had a condition

```
            "Condition": {
                "StringEquals": {
                    "s3:ResourceAccount": [
                        "<MAAP OPS ACCOUNT ID>"
                    ]
                }
            }
```

updating this policy with the account id of the maap-landing-zone worked for some operations such as GetObject, however the permissions boundary still had a DENY for PutObjectAcl which meant the uploadFiles operation still wouldn't work with the `ExtraArgs={'ACL': 'bucket-owner-full-control'}`

We decided to create a new bucket in GCC Ops `maap-landing-zone-gccops` to workaround these cross-account issues.

I tested this update in ade.ops.maap-project.org and was able to upload files to the new bucket.