### PR TITLE
Hotfix/issue 27 28 get data defaults

### DIFF
--- a/maap/Result.py
+++ b/maap/Result.py
@@ -1,10 +1,11 @@
-import requests
-import shutil
 import os
+import shutil
 import urllib
-import boto3
-import re
 from urllib.parse import urlparse
+
+import boto3
+import requests
+
 from maap.utils import endpoints
 
 

--- a/maap/Result.py
+++ b/maap/Result.py
@@ -3,14 +3,18 @@ import shutil
 import os
 import urllib
 import boto3
+import re
 from urllib.parse import urlparse
 from maap.utils import endpoints
+
 
 class Result(dict):
     """
     The class to structure the response xml string from the cmr API
     """
+
     _location = None
+    _fallback = None
 
     def getData(self, destpath=".", overwrite=False):
         """
@@ -20,32 +24,32 @@ class Result(dict):
         :return:
         """
         url = self._location
-        destfile = self._downloadname.replace('/', '')
+        destfile = self._downloadname.replace("/", "")
 
         if not url:
             # Downloadable url does not exist
             return None
-        if url.startswith('ftp'):
-            if not overwrite and not os.path.isfile(destpath + "/" + destfile):
-                urllib.urlretrieve(url, destpath + "/" + destfile)
+        if url.startswith("ftp"):
+            if not overwrite and not os.path.isfile(f"{destpath}/{destfile}"):
+                urllib.urlretrieve(url, f"{destpath}/{destfile}")
 
-            return destpath + '/' + destfile
-        elif url.startswith('s3'):
+            return destpath + "/" + destfile
+        elif url.startswith("s3"):
             try:
                 o = urlparse(url)
-                filename = url[url.rfind("/") + 1:]
-                if not overwrite and not os.path.isfile(destpath + "/" + filename):
-                    s3 = boto3.client('s3')
-                    s3.download_file(o.netloc, o.path.lstrip('/'), destpath + "/" + filename)
+                filename = os.path.basename(o.path)
+                if not overwrite and not os.path.isfile(f"{destpath}/{filename}"):
+                    s3 = boto3.client("s3")
+                    s3.download_file(
+                        o.netloc, o.path.lstrip("/"), f"{destpath}/{filename}"
+                    )
             except:
-
                 # Fallback to HTTP
-                http_url = self._convertS3toHttp(url)
-                return self._getHttpData(http_url, overwrite, destpath, destfile)
+                return self._getHttpData(self._fallback, overwrite, destpath, destfile)
 
-            return destpath + '/' + filename
-        else:
-            return self._getHttpData(url, overwrite, destpath, destfile)
+            return f"{destpath}/{filename}"
+        # else:
+        #     return self._getHttpData(url, overwrite, destpath, destfile)
 
     def getLocalPath(self, destpath=".", overwrite=False):
         """
@@ -54,9 +58,9 @@ class Result(dict):
         return self.getData(destpath, overwrite)
 
     def _convertS3toHttp(self, url):
-        url = url[5:].split('/')
-        url[0] += '.s3.amazonaws.com'
-        url = 'https://' + '/'.join(url)
+        url = url[5:].split("/")
+        url[0] += ".s3.amazonaws.com"
+        url = "https://" + "/".join(url)
         return url
 
     # When retrieving granule data, always try an unauthenticated HTTPS request first,
@@ -74,20 +78,22 @@ class Result(dict):
             # Try with a federated token if unauthorized
             if r.status_code == 401:
                 r = requests.get(
-                    url=os.path.join(self._cmrFileUrl,
-                                     urllib.parse.quote(urllib.parse.quote(url, safe='')),
-                                     endpoints.CMR_ALGORITHM_DATA),
+                    url=os.path.join(
+                        self._cmrFileUrl,
+                        urllib.parse.quote(urllib.parse.quote(url, safe="")),
+                        endpoints.CMR_ALGORITHM_DATA,
+                    ),
                     headers=self._apiHeader,
-                    stream=True
+                    stream=True,
                 )
 
             r.raise_for_status()
             r.raw.decode_content = True
 
-            with open(destpath + "/" + destfile, 'wb') as f:
+            with open(destpath + "/" + destfile, "wb") as f:
                 shutil.copyfileobj(r.raw, f)
 
-        return destpath + '/' + destfile
+        return destpath + "/" + destfile
 
     def getDownloadUrl(self):
         """
@@ -100,7 +106,14 @@ class Result(dict):
 
         :return:
         """
-        return self['Granule']['GranuleUR'].ljust(70) + 'Updated ' + self['Granule']['LastUpdate'] + ' (' + self['collection-concept-id'] + ')'
+        return (
+            self["Granule"]["GranuleUR"].ljust(70)
+            + "Updated "
+            + self["Granule"]["LastUpdate"]
+            + " ("
+            + self["collection-concept-id"]
+            + ")"
+        )
 
 
 class Collection(Result):
@@ -108,12 +121,16 @@ class Collection(Result):
         for k in metaResult:
             self[k] = metaResult[k]
 
-        self._location = 'https://{}/search/concepts/{}.umm-json'.format(maap_host, metaResult['concept-id'])
-        self._downloadname = metaResult['Collection']['ShortName']
+        self._location = "https://{}/search/concepts/{}.umm-json".format(
+            maap_host, metaResult["concept-id"]
+        )
+        self._downloadname = metaResult["Collection"]["ShortName"]
 
 
 class Granule(Result):
-    def __init__(self, metaResult, awsAccessKey, awsAccessSecret, cmrFileUrl, apiHeader):
+    def __init__(
+        self, metaResult, awsAccessKey, awsAccessSecret, cmrFileUrl, apiHeader
+    ):
 
         self._awsKey = awsAccessKey
         self._awsSecret = awsAccessSecret
@@ -125,26 +142,52 @@ class Granule(Result):
 
         # Retrieve downloadable url
         try:
-            self._location = self['Granule']['OnlineAccessURLs']['OnlineAccessURL']['URL']
-            self._downloadname = self._location.split("/")[-1]
-        except :
+            self._location = next(
+                (
+                    obj["URL"]
+                    for obj in self["Granule"]["OnlineAccessURLs"]
+                    if obj["URL"].startswith("s3://")
+                )
+            )
+
+            if self._location:
+                o = urlparse(self._location)
+                filename = os.path.basename(o.path)
+
+            self._fallback = next(
+                (
+                    obj["URL"]
+                    for obj in self["Granule"]["OnlineAccessURLs"]
+                    if obj["URL"].startswith("https://")
+                    and obj["URL"].endswith(filename)
+                ),
+                None,
+            )
+
+            self._downloadname = filename
+        except:
             self._location = None
+            self._fallback = None
 
         # TODO: make self._location an array and consolidate with _relatedUrls
         try:
-            self._relatedUrls = self['Granule']['OnlineAccessURLs']['OnlineAccessURL']
-            self._location = self['Granule']['OnlineAccessURLs']['OnlineAccessURL'][0]['URL']
+            self._relatedUrls = self["Granule"]["OnlineAccessURLs"]["OnlineAccessURL"]
+            self._location = self["Granule"]["OnlineAccessURLs"]["OnlineAccessURL"][0][
+                "URL"
+            ]
             self._downloadname = self._location.split("/")[-1]
-        except :
+        except:
             self._relatedUrls = None
 
         # Retrieve OPeNDAPUrl
         try:
-            urls = self['Granule']['OnlineResources']['OnlineResource']
+            urls = self["Granule"]["OnlineResources"]["OnlineResource"]
             # This throws an error "filter object is not subscriptable"
-            self._OPeNDAPUrl = filter(lambda x: x["Type"] == "OPeNDAP", urls)['URL']
-            self._BrowseUrl = list(filter(lambda x: x["Type"] == "BROWSE", urls))[0]['URL']
-        except :
+            self._OPeNDAPUrl = filter(lambda x: x["Type"] == "OPeNDAP", urls)["URL"]
+            self._BrowseUrl = list(filter(lambda x: x["Type"] == "BROWSE", urls))[0][
+                "URL"
+            ]
+        except:
             self._OPeNDAPUrl = None
             self._BrowseUrl = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-pytest==3.1.1
-urllib3==1.21.1
-requests
+black
+boto3-stubs[s3]
+botocore-stubs
+isort
+moto
+pytest
 responses
-boto3
-botocore
-mapboxgl
-ipython
+urllib3

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     include_package_data=True,
     install_requires=_requirements,
     setup_requires=['pytest-runner'],
-    tests_require=['pytest', 'responses'],
+    tests_require=['pytest', 'responses', 'moto'],
     keywords=_keywords,
     license=_license,
     long_description=_long_description,

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,4 +1,10 @@
+import os
+from typing import Iterable
+
+import boto3
 import pytest
+from moto import mock_s3
+from mypy_boto3_s3.client import S3Client
 
 from maap.AWS import AWS
 
@@ -11,3 +17,19 @@ def aws() -> AWS:
         "https://test_earthdata_s3_credentials_endpoint.com",
         {},
     )
+
+
+@pytest.fixture(scope="function")
+def aws_credentials() -> None:
+    """Mocked AWS Credentials for moto."""
+    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+    os.environ["AWS_SECURITY_TOKEN"] = "testing"
+    os.environ["AWS_SESSION_TOKEN"] = "testing"
+    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+
+
+@pytest.fixture(scope="function")
+def s3(aws_credentials) -> Iterable[S3Client]:
+    with mock_s3():
+        yield boto3.client("s3", region_name="us-east-1")


### PR DESCRIPTION
### Fixes

- Added _fallback incase _location fails ([0c0bdd1](https://github.com/MAAP-Project/maap-py/commit/0c0bdd19ab912ef7f73cf0d72339820581380bf6))
- add granule download tests ([f868105](https://github.com/MAAP-Project/maap-py/pull/40/commits/f868105f4898a8f1393231205f5b9d107b833c51))

### Chores

- additional isort/black ([bfb6879](https://github.com/MAAP-Project/maap-py/commit/bfb6879cda5bcf9f22d393e8aa50036596da4641))
- Added tests to test_Result ([bc19b60](https://github.com/MAAP-Project/maap-py/pull/40/commits/bc19b602d746ad17d76faa17212e8327648f47d6))