### PR TITLE
Bugs/dependency issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ _classifiers = [
 ]
 _description = 'maapPy Python API'
 _download_url = ''
-_requirements = ["backoff", "boto3", "ConfigParser", "ipython==8.12.0", "mapboxgl", "moto", "mypy_boto3_s3", "pytest",
+_requirements = ["backoff", "boto3==1.33.13", "ConfigParser", "ipython==8.12.0", "mapboxgl", "moto", "mypy_boto3_s3", "pytest",
                  "PyYAML", "requests", "responses", "setuptools"]
 _keywords = ['dataset', 'granule', 'nasa', 'MAAP', 'CMR']
 _license = 'Apache License, Version 2.0'

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ _classifiers = [
 ]
 _description = 'maapPy Python API'
 _download_url = ''
-_requirements = ["backoff", "boto3", "ConfigParser", "ipython", "mapboxgl", "pytest",
-                 "PyYAML", "responses", "setuptools"]
+_requirements = ["backoff", "boto3", "ConfigParser", "mapboxgl", "moto", "mypy_boto3_s3", "pytest",
+                 "PyYAML", "requests", "responses", "setuptools"]
 _keywords = ['dataset', 'granule', 'nasa', 'MAAP', 'CMR']
 _license = 'Apache License, Version 2.0'
 _long_description = 'Python client API for interacting with the NASA MAAP API'

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,8 @@ _classifiers = [
 ]
 _description = 'maapPy Python API'
 _download_url = ''
-_requirements = ["backoff", "boto3", "ConfigParser", "ipython", "mapboxgl", "moto", "mypy_boto3_s3", "pytest",
-                 "PyYAML", "requests", "responses", "setuptools"]
+_requirements = ["backoff", "boto3", "ConfigParser", "ipython", "mapboxgl", "pytest",
+                 "PyYAML", "responses", "setuptools"]
 _keywords = ['dataset', 'granule', 'nasa', 'MAAP', 'CMR']
 _license = 'Apache License, Version 2.0'
 _long_description = 'Python client API for interacting with the NASA MAAP API'

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ _classifiers = [
 ]
 _description = 'maapPy Python API'
 _download_url = ''
-_requirements = ["backoff", "boto3", "ConfigParser", "mapboxgl", "moto", "mypy_boto3_s3", "pytest",
+_requirements = ["backoff", "boto3", "ConfigParser", "ipython==8.12.0", "mapboxgl", "moto", "mypy_boto3_s3", "pytest",
                  "PyYAML", "requests", "responses", "setuptools"]
 _keywords = ['dataset', 'granule', 'nasa', 'MAAP', 'CMR']
 _license = 'Apache License, Version 2.0'


### PR DESCRIPTION
Pinning the versions of ipython and boto3 to avoid dependency errors installing maap-py for the workspace updates that @anilnatha and I have been working on
Pinning the version of ipython resolved this error:
```
#11 51.74 awscli 2.14.1 requires cryptography<40.0.2,>=3.3.2, but you have cryptography 40.0.2 which is incompatible.
#11 51.74 awscli 2.14.1 requires prompt-toolkit<3.0.39,>=3.0.24, but you have prompt-toolkit 3.0.43 which is incompatible.
```

Pinning the version of boto3 resolved this error:
```
aiobotocore 2.9.0 requires botocore<1.33.14,>=1.33.2, but you have botocore 1.34.3 which is incompatible.
```