### PR TITLE
added pagination to listJobs endpoint

### DIFF
--- a/maap/maap.py
+++ b/maap/maap.py
@@ -259,28 +259,18 @@ class MAAP(object):
     def listJobs(self, username=None, page_size=None, offset=None):
         if username==None and self.profile is not None and 'username' in self.profile.account_info().keys():
             username = self.profile.account_info()['username']
+
+        url = os.path.join(self.config.dps_job, username, endpoints.DPS_JOB_LIST)
+        params = {k: v for k, v in (("page_size", page_size), ("offset", offset)) if v}
         
-        query_params = []
-        if page_size is not None:
-            query_params.append(f"page_size={page_size}")
-        if offset is not None:
-            query_params.append(f"offset={offset}")
-
-        query_string = "&".join(query_params)
-
-        if query_string:
-            endpoint = endpoints.DPS_JOB_LIST + "?" + query_string
-            url = os.path.join(self.config.dps_job, username, endpoint)
-        else:
-            url = os.path.join(self.config.dps_job, username, endpoints.DPS_JOB_LIST)
-
         headers = self._get_api_header()
         logger.debug('GET request sent to {}'.format(url))
         logger.debug('headers:')
         logger.debug(headers)
         response = requests.get(
             url=url,
-            headers=headers
+            headers=headers,
+            params=params,
         )
         return response
 

--- a/maap/maap.py
+++ b/maap/maap.py
@@ -256,10 +256,24 @@ class MAAP(object):
         job.id = jobid
         return job.cancel_job()
 
-    def listJobs(self, username=None):
+    def listJobs(self, username=None, page_size=None, offset=None):
         if username==None and self.profile is not None and 'username' in self.profile.account_info().keys():
             username = self.profile.account_info()['username']
-        url = os.path.join(self.config.dps_job, username, endpoints.DPS_JOB_LIST)
+        
+        query_params = []
+        if page_size is not None:
+            query_params.append(f"page_size={page_size}")
+        if offset is not None:
+            query_params.append(f"offset={offset}")
+
+        query_string = "&".join(query_params)
+
+        if query_string:
+            endpoint = endpoints.DPS_JOB_LIST + "?" + query_string
+            url = os.path.join(self.config.dps_job, username, endpoint)
+        else:
+            url = os.path.join(self.config.dps_job, username, endpoints.DPS_JOB_LIST)
+
         headers = self._get_api_header()
         logger.debug('GET request sent to {}'.format(url))
         logger.debug('headers:')


### PR DESCRIPTION
Added optional pagination parameters to listJobs endpoint. Sample maap-py calls and their corresponding MAAP API requests:

`r = maap.listJobs("mlucas") :
https://api.dit.maap-project.org/api/dps/job/mlucas/list
`

` r = maap.listJobs("mlucas", 20, 10) :
https://api.dit.maap-project.org/api/dps/job/mlucas/list?page_size=20&offset=10
`

Work needed for [this ticket](https://app.zenhub.com/workspaces/maap-platform-5ee7f0d1f440de0024cd359b/issues/gh/maap-project/community/1027)

