### PR TITLE
Fix DPSJob.wait_for_completion() race condition with initial delay

### DIFF
--- a/maap/dps/dps_job.py
+++ b/maap/dps/dps_job.py
@@ -45,6 +45,7 @@ See Also
 import json
 import logging
 import os
+import time
 import xml.etree.ElementTree as ET
 import backoff
 from urllib.parse import urljoin
@@ -227,12 +228,19 @@ class DPSJob:
         return self.status
 
     @backoff.on_exception(backoff.expo, Exception, max_value=64, max_time=172800)
-    def wait_for_completion(self):
+    def wait_for_completion(self, initial_delay_seconds=5):
         """
         Wait for the job to complete.
 
         Blocks execution until the job finishes (succeeds, fails, or is
         cancelled). Uses exponential backoff to poll for status updates.
+
+        Parameters
+        ----------
+        initial_delay_seconds : float, optional
+            Initial delay in seconds before first status check (default: 5).
+            This accounts for the time required for newly submitted jobs to
+            become visible in the database. Set to 0 to disable initial delay.
 
         Returns
         -------
@@ -254,14 +262,22 @@ class DPSJob:
         - Uses exponential backoff with max interval of 64 seconds
         - Maximum wait time is 48 hours (172800 seconds)
         - The job object is updated with final status upon completion
+        - Initial delay accounts for database visibility delay (~5 seconds)
 
         See Also
         --------
         :meth:`retrieve_status` : Check status without blocking
         :meth:`cancel_job` : Cancel a running job
         """
+        # Wait before first check to allow newly submitted jobs to appear in database
+        if initial_delay_seconds > 0:
+            logger.debug(f'Waiting {initial_delay_seconds} seconds before first status check')
+            time.sleep(initial_delay_seconds)
+
         self.retrieve_status()
-        if self.status.lower() in ["accepted", "running"]:
+        # Known terminal states and states that should trigger retries
+        terminal_states = ["succeeded", "failed", "dismissed", "deduped", "offline"]
+        if self.status.lower() not in terminal_states:
             logger.debug('Current Status is {}. Backing off.'.format(self.status))
             raise RuntimeError
         return self


### PR DESCRIPTION
## Summary
Fixes the race condition in `DPSJob.wait_for_completion()` where the method would return immediately with an incorrect "Deleted" status if called right after job submission, before the job appears in the OpenSearch database.

## Problem
- When jobs are submitted via DPS API, they take up to 5 seconds to appear in the OpenSearch database
- If `wait_for_completion()` is called immediately after submission, the API returns an unexpected status before the job appears in the database
- The method would return immediately with this incorrect status instead of retrying

## Solution
Implemented an initial delay mechanism:
- Added `initial_delay_seconds` parameter (default 5 seconds) to `wait_for_completion()`
- The method now waits 5 seconds before the first status check, allowing the job to appear in the database
- Improved status check logic to properly handle all non-terminal states by retrying

## Changes
- ✅ Added `time` module import
- ✅ Added `initial_delay_seconds` parameter with default value of 5 seconds
- ✅ Added initial sleep before first status check
- ✅ Changed status check logic from whitelist (accepted/running) to blacklist (terminal states)
- ✅ Updated docstring with parameter documentation

## Testing
Users can now reliably call `wait_for_completion()` immediately after job submission:

```python
job = maap.submit_job(...)
job.wait_for_completion()  # Waits 5 seconds then polls correctly
print(f"Status: {job.status}")  # Returns "Succeeded" (or other terminal state)
```

To disable the initial delay for existing jobs (where status is already available):
```python
job.wait_for_completion(initial_delay_seconds=0)
```

## Related Issues
Fixes #126

https://claude.ai/code/session_01KEDGhwSuoY9N5inWR9bk5u

---
_Generated by [Claude Code](https://claude.ai/code/session_01KEDGhwSuoY9N5inWR9bk5u)_