### PR TITLE
fix: deploy GitHub Pages from master branch

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: Build Documentation
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, master, develop]
   pull_request:
-    branches: [main, develop]
+    branches: [main, master, develop]
   workflow_dispatch:
 
 permissions:
@@ -44,7 +44,7 @@ jobs:
           path: docs/_build/html
 
   deploy:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && github.event_name == 'push'
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/README.md
+++ b/README.md
@@ -2,18 +2,24 @@
 
 Python client library that abstracts [MAAP API](https://github.com/MAAP-Project/maap-api) calls including CMR querying, algorithm change management, and HySDS job execution. CMR components in this library are largely derived from the [pyCMR](https://github.com/nasa/pyCMR) library.
 
-## Setup
+## Installation
 
-Run:
+### From PyPI (recommended)
 
 ```bash
-python setup.py install
+pip install maap-py
 ```
 
-Or
+### For development
 
 ```bash
 pip install -e .
+```
+
+### Legacy
+
+```bash
+python setup.py install
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Added `master` to the `push` and `pull_request` branch triggers — the workflow was only watching `main` and `develop`, so pushes to `master` never triggered it
- Fixed the deploy condition to also match `refs/heads/master` — the deploy job was gated on `refs/heads/main` exclusively, so no deployment ever ran

## Root cause

The repo's default branch is `master`, but the workflow was written for `main`. GitHub Pages showed `status: null` (never deployed) as a result.

## Test plan

- [ ] Merge this PR — the `Build Documentation` workflow should trigger on the `master` push and the deploy job should run, publishing to https://maap-project.github.io/maap-py/